### PR TITLE
fix: open bird socket in read/write mode

### DIFF
--- a/bird.py
+++ b/bird.py
@@ -187,7 +187,7 @@ class Bird(object):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(self.socket)
         if sys.version_info >= (3, 0):
-            sock = sock.makefile(encoding='ascii')
+            sock = sock.makefile(encoding='ascii', mode='rw')
         else:
             sock = sock.makefile()
 


### PR DESCRIPTION
Python3 socket.makefile() mode defaults to 'r'(read-only) [1]
and essentially broke collectd bird plugin on Focal hypervisors
as the process could not write to bird's socket.

Exception trace in collectd.log:
```
  File "/usr/share/collectd/python/bird.py", line 200, in _query sock.write("restrict\n")
  io.UnsupportedOperation: not writable
```
Let's properly open the socket in read-write mode.

[1] https://docs.python.org/3/library/socket.html#socket.socket.makefile

Related to [ch24481]

### Testing

Monkey patched `/usr/share/collectd/python/bird.py` on ` virt-hv-pp058.gv2.p.exoscale.net` and collectd started emitting bird metrics:

<details> 

```
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR1_direct_public): All data sources are withi
n range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bi
rd_bgp","type_instance":"RR1_direct_public","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR0_direct_public): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR0_direct_public","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR0_indirect_public): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR0_indirect_public","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR1_indirect_public): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR1_indirect_public","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR0_direct_private): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR0_direct_private","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR1_direct_private): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR1_direct_private","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR0_indirect_private): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR0_indirect_private","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
{"message":"Host virt-hv-pp058.gv2.p.exoscale.net, plugin bird (instance v4) type bird_bgp (instance RR1_indirect_private): All data sources are within range again. Current value of \"state\" is 6.000000.","host":"virt-hv-pp058.gv2.p.exoscale.net","plugin":"bird","plugin_instance":"v4","type":"bird_bgp","type_instance":"RR1_indirect_private","severity":"ok","level":"info","@timestamp":"2021-01-19T13:42:30Z"}
```

</details>

I also verified they're visible on `infra-mon-pp001.gv2.p.exoscale.net` riemann.

Mind that this does not affect Bionic hypervisors where collectd still uses python2.